### PR TITLE
feat: add support for mixed html/js content

### DIFF
--- a/src/components/Editor.js
+++ b/src/components/Editor.js
@@ -1,6 +1,8 @@
 import React, { useRef, useEffect } from 'react';
 import 'codemirror/mode/javascript/javascript';
 import 'codemirror/mode/xml/xml';
+import 'codemirror/mode/css/css';
+import 'codemirror/mode/htmlmixed/htmlmixed';
 import 'codemirror/addon/edit/closetag';
 import 'codemirror/addon/fold/xml-fold';
 import 'codemirror/addon/scroll/simplescrollbars';
@@ -25,6 +27,11 @@ const options = {
   html: {
     ...baseOptions,
     mode: { name: 'text/html', multilineTagIndentPastTag: false },
+  },
+
+  htmlmixed: {
+    ...baseOptions,
+    mode: { name: 'htmlmixed' },
   },
 
   javascript: {

--- a/src/components/MarkupEditor.js
+++ b/src/components/MarkupEditor.js
@@ -16,7 +16,7 @@ function MarkupEditor({ markup, dispatch }) {
     <div className="h-full w-full flex flex-col">
       <div className="markup-editor flex-auto relative overflow-hidden">
         <Editor
-          mode="html"
+          mode="htmlmixed"
           initialValue={markup}
           onLoad={onLoad}
           onChange={onChange}

--- a/src/components/Preview.js
+++ b/src/components/Preview.js
@@ -38,14 +38,21 @@ function Preview({ markup, accessibleRoles, elements, dispatch }) {
     const container = document.createElement('div');
     container.innerHTML = markup;
     const scriptsCollections = container.getElementsByTagName('script');
-    return Array.from(scriptsCollections).map((script) => script.innerHTML);
+    return Array.from(scriptsCollections)
+      .filter(
+        (script) => script.type === 'text/javascript' || script.type === '',
+      )
+      .map((script) => ({
+        scriptCode: script.innerHTML,
+        toBeRemoved: script.outerHTML,
+      }));
   }, [markup]);
 
   const actualMarkup = useMemo(
     () =>
       scripts.length
         ? scripts.reduce(
-            (html, script) => html.replace(`<script>${script}</script>`, ''),
+            (html, script) => html.replace(script.toBeRemoved, ''),
             markup,
           )
         : markup,
@@ -56,7 +63,7 @@ function Preview({ markup, accessibleRoles, elements, dispatch }) {
     if (scripts.length) {
       try {
         scripts.forEach((script) => {
-          window.eval(script);
+          window.eval(script.scriptCode);
         });
       } catch {
         return;

--- a/src/components/Preview.js
+++ b/src/components/Preview.js
@@ -60,16 +60,17 @@ function Preview({ markup, accessibleRoles, elements, dispatch }) {
   );
 
   useEffect(() => {
-    if (scripts.length) {
+    if (scripts.length && htmlRoot.current) {
       try {
         scripts.forEach((script) => {
-          window.eval(script.scriptCode);
+          const executeScript = new Function(script.scriptCode);
+          executeScript();
         });
       } catch {
         return;
       }
     }
-  }, [scripts]);
+  }, [scripts, htmlRoot.current]);
 
   useEffect(() => {
     setRoles(Object.keys(accessibleRoles || {}).sort());

--- a/src/components/Preview.js
+++ b/src/components/Preview.js
@@ -60,15 +60,15 @@ function Preview({ markup, accessibleRoles, elements, dispatch }) {
   );
 
   useEffect(() => {
-    if (scripts.length && htmlRoot.current) {
-      try {
-        scripts.forEach((script) => {
+    if (htmlRoot.current) {
+      scripts.forEach((script) => {
+        try {
           const executeScript = new Function(script.scriptCode);
           executeScript();
-        });
-      } catch {
-        return;
-      }
+        } catch (e) {
+          alert('Failing script inserted in markup!');
+        }
+      });
     }
   }, [scripts, htmlRoot.current]);
 


### PR DESCRIPTION
Working on #10 , I have enabled:

1. html mixed mode in `MarkupEditor`, syntax highlighting working even for js script now
2. script tag are now retrieved in `Preview` component and evaluated through `window.eval`. Before `markup` is passed as `Scrollable` child in `dangerouslySetInnerHtml` all the `script` elements are removed.

Right now, this kind of code:
```html
<label for="checkbox">Check</label>
<input
  id="checkbox"
  type="checkbox"
/>
<button id="btn">
  Accept
</button>

<button id="btn2">
Decline
</button>

<script>
  const btn = document.getElementById('btn');
  btn.addEventListener('click', () => {
    alert('click');
  });
</script>

<script>
  const btn2 = document.getElementById('btn2');
  btn2.addEventListener('click', () => {
    alert('click no');
  });
</script>
```
can be inserted by the user and the result is an interactive `Preview` panel.