### PR TITLE
fix: restore auto indent size in markup editor

### DIFF
--- a/src/components/Editor.js
+++ b/src/components/Editor.js
@@ -31,7 +31,7 @@ const options = {
 
   htmlmixed: {
     ...baseOptions,
-    mode: { name: 'htmlmixed' },
+    mode: { name: 'htmlmixed', multilineTagIndentPastTag: false },
   },
 
   javascript: {


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: https://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:
#128 changed the behavior of attribute indentations in the markup editor. This PR restores the old behavior.

<!-- Why are these changes necessary? -->

**Why**:
Because it looks better. Compare:

```html
<div 
     class="container">
</div>
<textarea
          class="input">
</textarea>
```

with:
```html
<div
  class="container">
</div>
<textarea
  class="input">
</textarea>
```

<!-- How were these changes implemented? -->

**How**:
Pass the `multilineTagIndentPastTag: false` option to `CodeMirror`

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
