### PR TITLE
feat: add support for `@testing-library/user-event`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13780,6 +13780,14 @@
         "react-transition-group": "^4.4.1"
       }
     },
+    "react-toggle": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/react-toggle/-/react-toggle-4.1.1.tgz",
+      "integrity": "sha512-+wXlMcSpg8SmnIXauMaZiKpR+r2wp2gMUteroejp2UTSqGTVvZLN+m9EhMzFARBKEw7KpQOwzCyfzeHeAndQGw==",
+      "requires": {
+        "classnames": "^2.2.5"
+      }
+    },
     "react-transition-group": {
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.1.tgz",

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "react-dom": "^16.13.1",
     "react-router-dom": "^5.2.0",
     "react-toastify": "^6.0.5",
+    "react-toggle": "^4.1.1",
     "react-virtualized-auto-sizer": "^1.0.2",
     "react-window": "^1.8.5"
   },
@@ -96,7 +97,7 @@
   "jest": {
     "verbose": true,
     "moduleNameMapper": {
-      "\\.(jpg|jpeg|png|svg)$": "<rootDir>/src/__mocks__/fileMock.js"
+      "\\.(jpg|jpeg|png|svg|css)$": "<rootDir>/src/__mocks__/fileMock.js"
     },
     "setupFilesAfterEnv": [
       "./tests/setupTests.js"

--- a/src/components/Playground.js
+++ b/src/components/Playground.js
@@ -29,7 +29,7 @@ function Playground() {
 
         <div className="flex-auto h-56 md:h-full">
           <Preview
-            markup={markup}
+            markup={result.markup}
             elements={result.elements}
             accessibleRoles={result.accessibleRoles}
             dispatch={dispatch}

--- a/src/components/Playground.js
+++ b/src/components/Playground.js
@@ -15,7 +15,7 @@ function onStateChange({ markup, query, result }) {
 const initialValues = state.load() || {};
 
 function Playground() {
-  const [{ markup, query, result }, dispatch] = usePlayground({
+  const [{ markup, query, result, eventExecuted }, dispatch] = usePlayground({
     onChange: onStateChange,
     ...initialValues,
   });
@@ -29,7 +29,7 @@ function Playground() {
 
         <div className="flex-auto h-56 md:h-full">
           <Preview
-            markup={result.markup}
+            markup={eventExecuted ? result.markup : markup}
             elements={result.elements}
             accessibleRoles={result.accessibleRoles}
             dispatch={dispatch}
@@ -45,7 +45,11 @@ function Playground() {
         </div>
 
         <div className="flex-auto h-56 md:h-full overflow-hidden">
-          <Result result={result} dispatch={dispatch} />
+          <Result
+            result={result}
+            eventExecuted={eventExecuted}
+            dispatch={dispatch}
+          />
         </div>
       </div>
     </div>

--- a/src/components/Result.js
+++ b/src/components/Result.js
@@ -4,6 +4,7 @@ import ResultQueries from './ResultQueries';
 import ResultSuggestion from './ResultSuggestion';
 import Scrollable from './Scrollable';
 import { emptyResult } from '../lib';
+import UserEventResult from './UserEventResult';
 
 function Result({ result, dispatch }) {
   if (result.error) {
@@ -11,7 +12,9 @@ function Result({ result, dispatch }) {
       <ErrorBox caption={result.error.message} body={result.error.details} />
     );
   }
-
+  if (result.expression && result.expression.userEvent) {
+    return <UserEventResult />;
+  }
   if (
     !result.expression ||
     !Array.isArray(result.elements) ||

--- a/src/components/Result.js
+++ b/src/components/Result.js
@@ -6,14 +6,16 @@ import Scrollable from './Scrollable';
 import { emptyResult } from '../lib';
 import UserEventResult from './UserEventResult';
 
-function Result({ result, dispatch }) {
+function Result({ result, eventExecuted, dispatch }) {
   if (result.error) {
     return (
       <ErrorBox caption={result.error.message} body={result.error.details} />
     );
   }
   if (result.expression && result.expression.userEvent) {
-    return <UserEventResult />;
+    return (
+      <UserEventResult eventExecuted={eventExecuted} dispatch={dispatch} />
+    );
   }
   if (
     !result.expression ||

--- a/src/components/UserEventResult.js
+++ b/src/components/UserEventResult.js
@@ -1,9 +1,20 @@
 import React from 'react';
+import Toggle from 'react-toggle';
+import 'react-toggle/style.css';
 
-const UserEventResult = () => {
+const UserEventResult = ({ eventExecuted, dispatch }) => {
+  const handleToggleChange = () =>
+    dispatch({
+      type: 'TOGGLE_EXECUTION',
+    });
+
+  const label = eventExecuted
+    ? 'showing the preview after user-event action is applied'
+    : 'showing the preview according to the original markup';
+
   return (
-    <div className="space-y-4 text-sm">
-      <div className="min-h-8">
+    <div className="flex flex-col h-full">
+      <div className="min-h-8 space-y-4 text-sm">
         <p>
           <a
             href="https://testing-library.com/docs/ecosystem-user-event"
@@ -15,6 +26,19 @@ const UserEventResult = () => {
           </a>{' '}
           method detected!
         </p>
+      </div>
+      <div className="flex-auto flex items-center">
+        <label className="w-full flex items-center justify-center">
+          <div className="flex-auto flex justify-center">
+            <Toggle
+              onChange={handleToggleChange}
+              defaultChecked={eventExecuted}
+            />
+          </div>
+          <span className="min-h-8 space-y-4 text-sm flex-auto flex">
+            {label}
+          </span>
+        </label>
       </div>
     </div>
   );

--- a/src/components/UserEventResult.js
+++ b/src/components/UserEventResult.js
@@ -1,0 +1,23 @@
+import React from 'react';
+
+const UserEventResult = () => {
+  return (
+    <div className="space-y-4 text-sm">
+      <div className="min-h-8">
+        <p>
+          <a
+            href="https://testing-library.com/docs/ecosystem-user-event"
+            rel="noopener noreferrer"
+            target="_blank"
+            className="font-bold"
+          >
+            @testing-library/user-event
+          </a>{' '}
+          method detected!
+        </p>
+      </div>
+    </div>
+  );
+};
+
+export default UserEventResult;

--- a/src/hooks/usePlayground.js
+++ b/src/hooks/usePlayground.js
@@ -47,6 +47,10 @@ function reducer(state, action) {
       };
     }
 
+    case 'TOGGLE_EXECUTION': {
+      return { ...state, eventExecuted: !state.eventExecuted };
+    }
+
     default: {
       throw new Error('Unknown action type: ' + action.type);
     }
@@ -65,6 +69,7 @@ function usePlayground(props) {
   const [state, dispatch] = useReducer(withLogging(reducer), {
     rootNode,
     markup,
+    eventExecuted: result ? result.markup !== markup : false,
     query,
     result,
   });

--- a/src/hooks/usePlayground.js
+++ b/src/hooks/usePlayground.js
@@ -74,7 +74,6 @@ function usePlayground(props) {
       onChange(state);
     }
   }, [state.result]);
-
   return [state, dispatch];
 }
 

--- a/src/parser.js
+++ b/src/parser.js
@@ -83,6 +83,7 @@ function getLastExpression(code) {
     level,
     args,
     call,
+    userEvent: minified.trim().startsWith('userEvent.'),
   };
 }
 


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: https://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

I am trying to enable user launching `user-event` methods in `QueryMarkup`.
Right now the `click` event is enabled while the others are not enabled yet.
Furthermore it could be useful to have a toggle to switch between the original state and the one obtained executing `user-event` inserted method.

<!-- Why are these changes necessary? -->

**Why**:

It would be an awesome feature like requested in issue #10 .

<!-- How were these changes implemented? -->

**How**:

1. add `userEvent` to `evaluator` context
2. make the execution to be effective
3. retrieve code obtained by the execution of the `user-event` query on original markup
4. inject new code in `result` and passing it to `Preview` in `Playground` component
5. add evaluation of scripts inserted by the user in `MarkupEditor` in `parser`
6. show a new message in `Result` when the user inserts a `user-event` method
7. add toggle to switch between state after and before `user-event` method execution
8. markup to be shown handled in `usePlayground` adding a new action type to reducer

<!-- Have you done all of these things?  -->

**Checklist**:

- [x]  add `userEvent` to `evaluator` context
- [ ]  make the execution to be effective (right now just the `click` method is working and performs an actual transformation on the original markup)
- [x] retrieve code obtained by the execution of the `user-event` query on original markup
- [x] inject new code in `result` and passing it to `Preview` in `Playground` component
- [x] add evaluation of scripts inserted by the user in `MarkupEditor` in `parser`
- [x] show a new message in `Result` when the user inserts a `user-event` method
- [x] add toggle to switch between state after and before `user-event` method execution
- [x] markup to be shown handled in `usePlayground` adding a new action type to reducer

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->

~~To achieve the complete resolution of #10 managing of state after and before `user-event` method execution is still needed.~~

Right now the only `user-event` method that seems work is `click`.
