### PR TITLE
fix: parser error on empty markup string, causing WSOD

### DIFF
--- a/src/parser.js
+++ b/src/parser.js
@@ -243,7 +243,7 @@ function runUnsafe({ rootNode, query }) {
 }
 
 function parse({ rootNode, markup, query, cacheId, prevResult }) {
-  if (!markup && !rootNode) {
+  if (typeof markup !== 'string' && !rootNode) {
     throw new Error('either markup or rootNode should be provided');
   }
 


### PR DESCRIPTION

**What**:
Bugfix related to #161 
The Guard was modified now the Error is thrown if rootNode isn't in scope and markup is not a `typeof` "string"

**Why**:
The parser was triggering true when all the HTML was removed from the codemirror by the user.

**Checklist**:
- [x] Tests
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

**Screenshot before the fix applied on live site (in original bug report)**
<img width="1427" alt="Screen Shot 2020-06-15 at 8 50 17 PM" src="https://user-images.githubusercontent.com/27247160/84848350-942e7e00-b018-11ea-8bd8-cab67852886e.png">

**Screenshot locally running with fix applied and the HTML manually removed** 
<img width="1422" alt="Screen Shot 2020-06-16 at 9 24 31 PM" src="https://user-images.githubusercontent.com/27247160/84848354-97296e80-b018-11ea-98ae-5cf7ea8f8f7f.png">

**Tests ran after the fix is applied.**
<img width="648" alt="Screen Shot 2020-06-16 at 9 29 58 PM" src="https://user-images.githubusercontent.com/27247160/84848355-97c20500-b018-11ea-9dcd-5c94b272550f.png">

