### PR TITLE
feat: add result suggestion to scrollable area for small screen support

### DIFF
--- a/src/components/Playground.js
+++ b/src/components/Playground.js
@@ -44,7 +44,7 @@ function Playground() {
           <Query query={query} result={result} dispatch={dispatch} />
         </div>
 
-        <div className="flex-auto overflow-auto">
+        <div className="flex-auto h-56 md:h-full overflow-hidden">
           <Result result={result} dispatch={dispatch} />
         </div>
       </div>

--- a/src/components/Playground.js
+++ b/src/components/Playground.js
@@ -44,7 +44,7 @@ function Playground() {
           <Query query={query} result={result} dispatch={dispatch} />
         </div>
 
-        <div className="flex-auto h-56 md:h-full overflow-hidden">
+        <div className="flex-auto overflow-auto">
           <Result result={result} dispatch={dispatch} />
         </div>
       </div>

--- a/src/components/Result.js
+++ b/src/components/Result.js
@@ -41,7 +41,7 @@ function Result({ result, dispatch }) {
   const { data, suggestion } = result.elements?.[0] || emptyResult;
 
   return (
-    <div className="flex flex-col w-full h-full overflow-hidden">
+    <div className="flex flex-col h-56">
       <div className="flex-none pb-4 border-b">
         <ResultSuggestion
           result={result}

--- a/src/components/Result.js
+++ b/src/components/Result.js
@@ -41,26 +41,24 @@ function Result({ result, dispatch }) {
   const { data, suggestion } = result.elements?.[0] || emptyResult;
 
   return (
-    <div className="flex flex-col h-56">
-      <div className="flex-none pb-4 border-b">
-        <ResultSuggestion
-          result={result}
-          dispatch={dispatch}
-          data={data}
-          suggestion={suggestion}
-        />
-      </div>
-
-      <div className="flex-auto">
-        <Scrollable>
-          <ResultQueries
+    <div className="flex flex-col w-full h-full overflow-hidden">
+      <Scrollable>
+        <div className="pb-4 border-b">
+          <ResultSuggestion
+            result={result}
+            dispatch={dispatch}
             data={data}
             suggestion={suggestion}
-            activeMethod={result.expression?.method}
-            dispatch={dispatch}
           />
-        </Scrollable>
-      </div>
+        </div>
+
+        <ResultQueries
+          data={data}
+          suggestion={suggestion}
+          activeMethod={result.expression?.method}
+          dispatch={dispatch}
+        />
+      </Scrollable>
     </div>
   );
 }


### PR DESCRIPTION
**What**:
Adding better scrolling for smaller screens like 11" Macbook.

[Original issue](https://github.com/testing-library/testing-playground/issues/149)

**Why**:
For better usability with people who have smaller screens.

**How**:
I got rid of the height on the main div around the `Result` Component and added `overflow-auto` and created a height on the inner component to trigger the scrollbar when it exceeds the height.

**Checklist**:

- [ ] Tests
- [ ] Ready to be merged

This is not ready to be merged, I am raising this in Draft mode to start a discussion on how to finish.

@smeijer There are two problems I have ran into:
1. I noticed the project uses tailwind but when I try and use `overflow-auto` is does not work, even though that is a valid style?
2. I cannot find where the query styles are coming from and in order to remove the inner scrollbar I need to be able to remove the style `overflow-scroll`. I have attached an image where I am hight lighting the dom node I need to fix but I cannot find where those are in the codebase.

<img width="879" alt="Screen Shot 2020-06-16 at 10 23 26 PM" src="https://user-images.githubusercontent.com/66570218/84858499-2dad5e00-b020-11ea-8309-2aa11d52721e.png">

I have also attached a gif below to show what I am trying to accomplish, in the browser I added the styling `overflow: auto` to the div that wraps `<Result />`

![testing_libary_scroll_bar](https://user-images.githubusercontent.com/66570218/84858820-c04dfd00-b020-11ea-8721-121500b9d708.gif)

Sorry if this is not the place to raise such discussions, I am a Junior Dev and still getting the hang of this... Any suggestions or tips on how to tackle these problems would be greatly appreciated!