### PR TITLE
fix: move target node for event logger a few nodes down

### DIFF
--- a/src/components/DomEvents.js
+++ b/src/components/DomEvents.js
@@ -157,8 +157,9 @@ function DomEvents() {
           <MarkupEditor markup={markup} dispatch={dispatch} />
         </div>
 
-        <div className="flex-auto h-56 md:h-full" ref={setPreviewRef}>
+        <div className="flex-auto h-56 md:h-full">
           <Preview
+            forwardedRef={setPreviewRef}
             markup={markup}
             elements={result.elements}
             accessibleRoles={result.accessibleRoles}
@@ -196,7 +197,6 @@ function DomEvents() {
               <AutoSizer>
                 {({ width, height }) => (
                   <StickyList
-                    follow={true}
                     mode="bottom"
                     ref={listRef}
                     height={height}

--- a/src/components/Preview.js
+++ b/src/components/Preview.js
@@ -1,4 +1,10 @@
-import React, { useState, useEffect, useRef, useMemo } from 'react';
+import React, {
+  useState,
+  useEffect,
+  useRef,
+  useMemo,
+  useCallback,
+} from 'react';
 import Scrollable from './Scrollable';
 import PreviewHint from './PreviewHint';
 import AddHtml from './AddHtml';
@@ -8,7 +14,14 @@ function selectByCssPath(rootNode, cssPath) {
   return rootNode?.querySelector(cssPath.toString().replace(/^body > /, ''));
 }
 
-function Preview({ markup, accessibleRoles, elements, dispatch, variant }) {
+function Preview({
+  markup,
+  accessibleRoles,
+  elements,
+  dispatch,
+  variant,
+  forwardedRef,
+}) {
   // Okay, listen up. `highlighted` can be a number of things, as I wanted to
   // keep a single variable to represent the state. This to reduce bug count
   // by creating out-of-sync states.
@@ -33,7 +46,13 @@ function Preview({ markup, accessibleRoles, elements, dispatch, variant }) {
     element: highlighted,
   });
 
-  // TestingLibraryDom?.getSuggestedQuery(highlighted, 'get').toString() : null
+  const refSetter = useCallback((node) => {
+    if (typeof forwardedRef === 'function') {
+      forwardedRef(node || null);
+    }
+
+    htmlRoot.current = node;
+  }, []);
 
   useEffect(() => {
     const container = document.createElement('div');
@@ -154,7 +173,7 @@ function Preview({ markup, accessibleRoles, elements, dispatch, variant }) {
             className="preview"
             onClick={handleClick}
             onMouseMove={handleMove}
-            ref={htmlRoot}
+            ref={refSetter}
             dangerouslySetInnerHTML={{
               __html: actualMarkup,
             }}

--- a/src/components/StickyList.js
+++ b/src/components/StickyList.js
@@ -3,7 +3,6 @@ import { FixedSizeList as List } from 'react-window';
 
 function StickyList(
   {
-    follow = false,
     mode = 'bottom',
     height,
     itemCount,
@@ -17,17 +16,14 @@ function StickyList(
 ) {
   const innerRef = useRef();
   useEffect(() => {
-    if (ref.current && follow && innerRef.current) {
-      if (
-        mode === 'bottom' &&
-        innerRef.current.offsetHeight > ref.current.props.height
-      ) {
+    if (ref.current && innerRef.current) {
+      if (mode === 'bottom') {
         ref.current.scrollTo(innerRef.current.offsetHeight);
       } else if (mode === 'top') {
         ref.current.scrollTo(0);
       }
     }
-  }, [itemCount, follow]);
+  }, [itemCount]);
 
   return (
     <List

--- a/src/components/StickyList.js
+++ b/src/components/StickyList.js
@@ -16,12 +16,18 @@ function StickyList(
 ) {
   const innerRef = useRef();
   useEffect(() => {
-    if (ref.current && innerRef.current) {
-      if (mode === 'bottom') {
-        ref.current.scrollTo(innerRef.current.offsetHeight);
-      } else if (mode === 'top') {
-        ref.current.scrollTo(0);
-      }
+    if (!ref.current || !innerRef.current) {
+      return;
+    }
+
+    if (innerRef.current.offsetHeight <= ref.current.props.height) {
+      return;
+    }
+
+    if (mode === 'bottom') {
+      ref.current.scrollTo(innerRef.current.offsetHeight);
+    } else {
+      ref.current.scrollTo(0);
     }
   }, [itemCount]);
 


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: https://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

I've changed the node to which `DomEvents` listens for events. The node was positioned inside `DomEvents`, now we're listening to the `Preview` root instead.

<!-- Why are these changes necessary? -->

**Why**:
Listening to a node that wraps the entire preview pane, causes unrelated events to be logged. This is because the `Preview` component doesn't only hold the raw markup, it also contains `Scrollable` and `AutoSizer` (resize detectors).

The `AutoSizer` triggers on page load, so it caused the first events to be directly added on-page load. This change fixes that as well.

<!-- How were these changes implemented? -->

**How**:
Use the callback ref to bind the events directly on the correct root node, instead of wrapping the entire `<Preview>` component.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
