### PR TITLE
feat: format editor content on blur

### DIFF
--- a/src/components/Editor.js
+++ b/src/components/Editor.js
@@ -11,6 +11,7 @@ import { queries } from '@testing-library/dom';
 
 import CodeMirror from 'codemirror';
 import debounce from 'lodash/debounce';
+import beautifier from '../lib/beautify';
 
 const baseOptions = {
   autoCloseBrackets: true,
@@ -198,6 +199,17 @@ function Editor({ onLoad, onChange, mode, initialValue }) {
           completeSingle: false,
         });
       }
+    });
+
+    editor.current.on('blur', () => {
+      let formattedText = editor.current.getValue();
+      if (mode === 'htmlmixed') {
+        formattedText = beautifier.beautifyHtml(editor.current.getValue());
+      } else if (mode === 'javascript') {
+        formattedText = beautifier.beautifyJs(editor.current.getValue());
+      }
+      editor.current.setValue(formattedText);
+      onChange(formattedText);
     });
 
     onLoad(editor.current);

--- a/src/lib/beautify.js
+++ b/src/lib/beautify.js
@@ -1,0 +1,20 @@
+import beautify from 'js-beautify';
+
+const beautifyOptions = {
+  indent_size: 2,
+  wrap_line_length: 72,
+  wrap_attributes: 'force-expand-multiline',
+};
+
+function beautifyHtml(html) {
+  return beautify.html(html, beautifyOptions);
+}
+
+function beautifyJs(js) {
+  return beautify.js(js, beautifyOptions);
+}
+
+export default {
+  beautifyHtml,
+  beautifyJs,
+};

--- a/src/lib/state.js
+++ b/src/lib/state.js
@@ -4,7 +4,7 @@ import {
 } from 'lz-string';
 import queryString from 'query-string';
 
-import beautify from 'js-beautify';
+import beautifier from '../lib/beautify';
 
 function unindent(string) {
   return (string || '').replace(/[ \t]*[\n][ \t]*/g, '\n');
@@ -21,13 +21,11 @@ export function compress({ markup, query }) {
 
 export function decompress({ markup, query }) {
   const result = {
-    markup: beautify.html(
+    markup: beautifier.beautifyHtml(
       decompressFromEncodedURIComponent(markup || ''),
-      beautifyOptions,
     ),
-    query: beautify.js(
+    query: beautifier.beautifyJs(
       decompressFromEncodedURIComponent(query || ''),
-      beautifyOptions,
     ),
   };
 
@@ -45,12 +43,6 @@ function save({ markup, query }) {
 
   history.replaceState(null, '', window.location.pathname + '?' + search);
 }
-
-const beautifyOptions = {
-  indent_size: 2,
-  wrap_line_length: 72,
-  wrap_attributes: 'force-expand-multiline',
-};
 
 function load() {
   const { hash, search } = window.location;


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: https://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->
fix #196 
**What**:

On blur both the editor for js and html are now formatted

**Why**:

Because formatted text are more beautiful 💅 

**How**:

Adding an event handler for onBlur 

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [X] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
