### PR TITLE
feat: format editor content on paste

### DIFF
--- a/src/components/Editor.js
+++ b/src/components/Editor.js
@@ -11,7 +11,7 @@ import { queries } from '@testing-library/dom';
 
 import CodeMirror from 'codemirror';
 import debounce from 'lodash/debounce';
-import beautifier from '../lib/beautify';
+import beautify from '../lib/beautify';
 
 const baseOptions = {
   autoCloseBrackets: true,
@@ -201,16 +201,21 @@ function Editor({ onLoad, onChange, mode, initialValue }) {
       }
     });
 
-    editor.current.on('blur', () => {
-      let formattedText = editor.current.getValue();
-      if (mode === 'htmlmixed') {
-        formattedText = beautifier.beautifyHtml(editor.current.getValue());
-      } else if (mode === 'javascript') {
-        formattedText = beautifier.beautifyJs(editor.current.getValue());
+    const format = () => {
+      const value = editor.current.getValue();
+      const formatted = beautify.format(mode, value);
+      editor.current.setValue(formatted);
+    };
+
+    editor.current.on('change', (_, change) => {
+      if (change.origin !== 'paste') {
+        return;
       }
-      editor.current.setValue(formattedText);
-      onChange(formattedText);
+
+      format();
     });
+
+    editor.current.on('blur', format);
 
     onLoad(editor.current);
   }, [editor.current, onChange]);

--- a/src/lib/beautify.js
+++ b/src/lib/beautify.js
@@ -6,15 +6,28 @@ const beautifyOptions = {
   wrap_attributes: 'force-expand-multiline',
 };
 
-function beautifyHtml(html) {
+function html(html) {
   return beautify.html(html, beautifyOptions);
 }
 
-function beautifyJs(js) {
+function js(js) {
   return beautify.js(js, beautifyOptions);
 }
 
+function format(mode, content) {
+  if (mode === 'htmlmixed' || mode === 'html') {
+    return html(content);
+  }
+
+  if (mode === 'javascript') {
+    return js(content);
+  }
+
+  return content;
+}
+
 export default {
-  beautifyHtml,
-  beautifyJs,
+  html,
+  js,
+  format,
 };

--- a/src/lib/state.js
+++ b/src/lib/state.js
@@ -4,7 +4,7 @@ import {
 } from 'lz-string';
 import queryString from 'query-string';
 
-import beautifier from '../lib/beautify';
+import beautify from '../lib/beautify';
 
 function unindent(string) {
   return (string || '').replace(/[ \t]*[\n][ \t]*/g, '\n');
@@ -21,12 +21,8 @@ export function compress({ markup, query }) {
 
 export function decompress({ markup, query }) {
   const result = {
-    markup: beautifier.beautifyHtml(
-      decompressFromEncodedURIComponent(markup || ''),
-    ),
-    query: beautifier.beautifyJs(
-      decompressFromEncodedURIComponent(query || ''),
-    ),
+    markup: beautify.html(decompressFromEncodedURIComponent(markup || '')),
+    query: beautify.js(decompressFromEncodedURIComponent(query || '')),
   };
 
   return result;


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: https://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:
Added `on paste` formatting on top of #197 

<!-- Why are these changes necessary? -->

**Why**:
Because if users paste their content, they might not realize that it will be formatted on blur. Formatting directly on paste, might prevent some manual formatting actions.

<!-- How were these changes implemented? -->

**How**:
Added an `on change` handler to CodeMirror, which ignores every change type except for the `paste` origin.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
