### PR TITLE
fix(extension): toggle inspecting on button click

### DIFF
--- a/devtools/src/content-script/highlighter/index.js
+++ b/devtools/src/content-script/highlighter/index.js
@@ -32,8 +32,17 @@ export default function setupHighlighter({
   Bridge.onMessage('CLEAR_HIGHLIGHTS', withMessageData(clearHighlights));
   Bridge.onMessage('HIGHLIGHT_ELEMENTS', withMessageData(highlightElements));
   Bridge.onMessage('SHUTDOWN', withMessageData(stopInspecting));
+  Bridge.onMessage('TOGGLE_INSPECTING', withMessageData(toggleInspecting));
   Bridge.onMessage('START_INSPECTING', withMessageData(startInspecting));
   Bridge.onMessage('STOP_INSPECTING', withMessageData(stopInspecting));
+
+  function toggleInspecting(options) {
+    if (isInspecting) {
+      stopInspecting();
+    } else {
+      startInspecting(options);
+    }
+  }
 
   function startInspecting(options) {
     isInspecting = true;

--- a/devtools/src/devtools/components/MenuBar.js
+++ b/devtools/src/devtools/components/MenuBar.js
@@ -9,14 +9,21 @@ import InspectIcon from './InspectIcon';
 import LogIcon from './LogIcon';
 
 function MenuBar({ cssPath, suggestion }) {
+  const isIspecting = React.useRef(false);
   return (
     <div className="h-8 p-2 border-b space-x-4 flex">
       <button
         className="focus:outline-none"
         title="select element"
-        onClick={() =>
-          Bridge.sendMessage('START_INSPECTING', null, 'content-script')
-        }
+        onClick={() => {
+          if (!isIspecting.current) {
+            Bridge.sendMessage('START_INSPECTING', null, 'content-script');
+            isIspecting.current = true;
+          } else {
+            Bridge.sendMessage('STOP_INSPECTING', null, 'content-script');
+            isIspecting.current = false;
+          }
+        }}
       >
         <SelectIcon />
       </button>

--- a/devtools/src/devtools/components/MenuBar.js
+++ b/devtools/src/devtools/components/MenuBar.js
@@ -9,20 +9,13 @@ import InspectIcon from './InspectIcon';
 import LogIcon from './LogIcon';
 
 function MenuBar({ cssPath, suggestion }) {
-  const isIspecting = React.useRef(false);
   return (
     <div className="h-8 p-2 border-b space-x-4 flex">
       <button
         className="focus:outline-none"
         title="select element"
         onClick={() => {
-          if (!isIspecting.current) {
-            Bridge.sendMessage('START_INSPECTING', null, 'content-script');
-            isIspecting.current = true;
-          } else {
-            Bridge.sendMessage('STOP_INSPECTING', null, 'content-script');
-            isIspecting.current = false;
-          }
+          Bridge.sendMessage('TOGGLE_INSPECTING', null, 'content-script');
         }}
       >
         <SelectIcon />


### PR DESCRIPTION
fix #228 

**What**: I have fixed an issue where the user can't disable inspecting after click on the icon

<!-- Why are these changes necessary? -->

**Why**: User can't use the browser without a refresh


**How**: By saving state in a ref and toggle inspecting checking this 

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [X] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
