### PR TITLE
fix emoji link in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,5 +140,5 @@ Contributions of any kind welcome!
 [contributing.md]: https://github.com/testing-library/testing-playground/blob/develop/CONTRIBUTING.md
 [issue tracker]: https://github.com/testing-library/testing-playground/issues
 [all-contributors]: https://github.com/all-contributors/all-contributors
-[emojis]: https://github.com/all-contributors/all-contributors#emoji-key
+[emojis]: https://allcontributors.org/docs/en/emoji-key
 [emojione]: https://www.emojione.com/emoji/1f9e


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: https://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

I have replace the emoji key link in readme.
Before it addressed to https://github.com/all-contributors/all-contributors#emoji-key, now to https://allcontributors.org/docs/en/emoji-key that I think is the right link to be addressed to.

<!-- Why are these changes necessary? -->

**Why**:

<!-- How were these changes implemented? -->

**How**:

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
