### PR TITLE
fix(devtools): (de)serialize query suggestions for msg transport

### DIFF
--- a/src/components/Editor.js
+++ b/src/components/Editor.js
@@ -153,7 +153,8 @@ const NON_TRIGGER_KEYS = {
 };
 
 function formatValue(cm) {
-  const mode = cm.options.mode;
+  // sometimes the mode is stored under `mode` and other times under `mode.name` :/
+  const mode = cm.options.mode.name || cm.options.mode;
   const value = cm.getValue();
   const formatted = beautify.format(mode, value);
   cm.setValue(formatted);

--- a/src/components/ResultQueries.js
+++ b/src/components/ResultQueries.js
@@ -10,6 +10,33 @@ function Heading({ children }) {
   return <h3 className="text-xs font-bold">{children}</h3>;
 }
 
+// The reviver parses serialized regexes back to a real regexp.
+// This function is required if the data comes in via message transport
+// think of the chrome-extension.
+function reviver(obj) {
+  if (typeof obj?.$regexp === 'string') {
+    return new RegExp(obj.$regexp, obj.$flags);
+  }
+
+  return obj;
+}
+
+// we use our own stringify method instead of the one from @testing-library/dom,
+// because it might have been removed for message transport.
+function suggestionToString({ queryArgs, queryMethod }) {
+  let [text, options] = queryArgs;
+
+  text = typeof text === 'string' ? `'${text}'` : reviver(text);
+
+  options = options
+    ? `, { ${Object.entries(options)
+        .map(([k, v]) => `${k}: ${reviver(v)}`)
+        .join(', ')} }`
+    : '';
+
+  return `${queryMethod}(${text}${options})`;
+}
+
 const Field = React.memo(function Field({
   data,
   method,
@@ -19,11 +46,12 @@ const Field = React.memo(function Field({
 }) {
   const field = getFieldName(method);
   const value = data[field];
+
   const handleClick = value
     ? () => {
         dispatch({
           type: 'SET_QUERY',
-          query: `screen.${query.toString()}`,
+          query: `screen.${suggestionToString(query)}`,
         });
       }
     : undefined;

--- a/src/parser.js
+++ b/src/parser.js
@@ -14,6 +14,11 @@ import {
 
 import userEvent from '@testing-library/user-event';
 
+// Patch RegeXP so we have a (better) way to serialize for message transport
+RegExp.prototype.toJSON = function () {
+  return { $regexp: this.source, $flags: this.flags };
+};
+
 const debug = (element, maxLength, options) =>
   Array.isArray(element)
     ? element.map((el) => logDOM(el, maxLength, options)).join('\n')


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: https://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:
Fix suggestion buttons in chrome extension.

<!-- Why are these changes necessary? -->

**Why**:
The suggestions are transported by `postMessage` from the page to the extension pane. This causes the data to be serialized and unserialized. But, `JSON.stringify({ foo: /regexp/i })` doesn't work!

<!-- How were these changes implemented? -->

**How**:
I've done two things here.

1. create a `toString` method that parses the query suggestion back to a full string. This fixes a `screen.[object Object]` bug, as we remove the `toString` method before handing it over to `postMessage`.

2. add a `toJSON` method and a `reviver` to serialize/deserialize RegExp's. This fixes a second bug, where queries like `screen.getByRole('button', { name: {} })` were generated.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
