### PR TITLE
fix: incorrect detection of editor mode

### DIFF
--- a/src/components/Editor.js
+++ b/src/components/Editor.js
@@ -153,7 +153,8 @@ const NON_TRIGGER_KEYS = {
 };
 
 function formatValue(cm) {
-  const mode = cm.options.mode;
+  // sometimes the mode is stored under `mode` and other times under `mode.name` :/
+  const mode = cm.options.mode.name || cm.options.mode;
   const value = cm.getValue();
   const formatted = beautify.format(mode, value);
   cm.setValue(formatted);


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: https://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:
fix editor mode detection for automated formatting

<!-- Why are these changes necessary? -->

**Why**:
this fix exists on `live` but wasn't backported to `develop` yet
<!-- How were these changes implemented? -->

**How**:
For some reason, `options.mode` is sometimes a string like `html`, and sometimes an object like `{ name: 'html' }`. Fix is a simple one-liner:

```
const mode = cm.options.mode.name || cm.options.mode;
```

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
