### PR TITLE
fix: add reach css selectors to purgecss whitelist

### DIFF
--- a/postcss.config.js
+++ b/postcss.config.js
@@ -22,8 +22,13 @@ if (IS_PRODUCTION) {
         'devtools/**/*.js',
         'devtools/**/*.html',
       ],
-      whitelist: ['body', /CodeMirror/, /react-toggle/],
-      whitelistPatternsChildren: [/CodeMirror/, /cm-s-dracula/, /react-toggle/],
+      whitelist: ['body', /CodeMirror/, /react-toggle/, /data-reach/],
+      whitelistPatternsChildren: [
+        /CodeMirror/,
+        /cm-s-dracula/,
+        /react-toggle/,
+        /data-reach/,
+      ],
       defaultExtractor: TailwindExtractor.extract,
     }),
   );


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: https://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:
Add `data-reach` to the `whitelist` of `purgecss`
<!-- Why are these changes necessary? -->

**Why**:
To fix the problem reported here: https://github.com/testing-library/testing-playground/pull/240#issuecomment-653893811

<!-- How were these changes implemented? -->

**How**:
Update `postcsss.config.js`
<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
