### PR TITLE
retrieve role even for input element with type not text (#246)

### DIFF
--- a/src/lib/queryAdvise.js
+++ b/src/lib/queryAdvise.js
@@ -20,9 +20,7 @@ export function getData({ rootNode, element }) {
   return {
     role: element.getAttribute('aria-hidden')
       ? undefined
-      : element.getAttribute('role') ||
-        // input's require a type for the role
-        (tagName === 'INPUT' && type !== 'text' ? '' : getRole(element)),
+      : element.getAttribute('role') || getRole(element),
     name: computeAccessibleName(element),
     tagName: tagName,
     type: type,


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: https://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

Role field are set in `ResultQueries` even when they are related to an `input` element regardless of the `type` attribute.

<!-- Why are these changes necessary? -->

**Why**:

In order to provide a more consistent information, because before the `role` query was rightly suggested but not shown in `ResultQueries`.
<!-- How were these changes implemented? -->

**How**:

<!-- Have you done all of these things?  -->

**Checklist**:

- [x] remove condition that make `getRole` to be called even the selected element is an `input` with a type different from `text`.

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
