### PR TITLE
fix(devtools): escape newlines in logged queries

### DIFF
--- a/devtools/src/devtools/lib/inspectedWindow.js
+++ b/devtools/src/devtools/lib/inspectedWindow.js
@@ -6,9 +6,13 @@
 // recent(ly) used element(s), assign an id to them, and then use messaging. But
 // for now, this is way easier.
 
+function escape(str) {
+  return str.replace(/'/g, "\\'").replace(/\n/g, '\\n');
+}
+
 function logQuery(query) {
   chrome.devtools.inspectedWindow.eval(`
-    console.log('${query.replace(/'/g, "\\'")}');
+    console.log('${escape(query)}');
     console.log(eval(${query}));
   `);
 }


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: https://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:
Escape queries before logging them to `inspectedWindow`

<!-- Why are these changes necessary? -->

**Why**:
If we don't escape them, they won't be logged.
<!-- How were these changes implemented? -->

**How**:
Add slashes before single quotes and newlines.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
