### PR TITLE
refactor: only parse queries in sandbox

### DIFF
--- a/src/hooks/usePlayground.js
+++ b/src/hooks/usePlayground.js
@@ -311,6 +311,9 @@ function usePlayground(props) {
     if (typeof onChange === 'function') {
       onChange(state);
     }
+    // ignore the exhaustive deps. We really want to call onChange with the full
+    // state object, but only when `state.result` has changed.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [state.result, onChange]);
 
   // propagate sandbox ready/busy events to playground state

--- a/src/hooks/usePlayground.js
+++ b/src/hooks/usePlayground.js
@@ -159,10 +159,6 @@ const configureSandbox = (state) => {
 };
 
 const populateSandboxDebounced = debounce(populateSandbox, 250);
-const parseDebounced = debounce((data, dispatch) => {
-  const result = parser.parse(data);
-  dispatch({ type: 'SET_RESULT', result });
-}, 250);
 
 const effectMap = {
   UPDATE_SANDBOX: (state, effect, dispatch) => {
@@ -171,20 +167,10 @@ const effectMap = {
       return;
     }
 
-    const data = {
-      markup: state.markup,
-      query: state.query,
-      rootNode: state.rootNode,
-      prevResult: state.result,
-    };
-
     if (state.settings.autoRun) {
       populateSandboxDebounced(state, effect, dispatch);
-      parseDebounced(data, dispatch);
     } else if (effect.immediate) {
       populateSandbox(state, effect, dispatch);
-      const result = parser.parse(data);
-      dispatch({ type: 'SET_RESULT', result });
     }
   },
 
@@ -267,13 +253,10 @@ const effectMap = {
 function getInitialState(props) {
   const localSettings = JSON.parse(localStorage.getItem('playground_settings'));
 
-  let { instanceId } = props;
-
   const state = {
     ...props,
     status: 'loading',
     dirty: false,
-    cacheId: instanceId,
     settings: Object.assign(
       {
         autoRun: true,
@@ -332,13 +315,14 @@ function usePlayground(props) {
 
   // propagate sandbox ready/busy events to playground state
   useEffect(() => {
-    const listener = ({ data: { source, type } }) => {
+    const listener = ({ data: { source, type, result } }) => {
       if (source !== 'testing-playground-sandbox') {
         return;
       }
 
       if (type === 'SANDBOX_READY') {
         dispatch({ type: 'SET_STATUS', status: 'idle' });
+        dispatch({ type: 'SET_RESULT', result });
       } else if (type === 'SANDBOX_BUSY') {
         dispatch({ type: 'SET_STATUS', status: 'evaluating' });
       }

--- a/src/sandbox.js
+++ b/src/sandbox.js
@@ -119,8 +119,20 @@ function onSelectNode(node, { origin }) {
 function updateSandbox(rootNode, markup, query) {
   postMessage({ type: 'SANDBOX_BUSY' });
   setInnerHTML(rootNode, markup);
-  runQuery(rootNode, query);
-  postMessage({ type: 'SANDBOX_READY' });
+
+  // get and clean result
+  // eslint-disable-next-line no-unused-vars
+  const { markup: m, query: q, ...data } = runQuery(rootNode, query);
+
+  const result = {
+    ...data,
+    accessibleRoles: Object.keys(data.accessibleRoles).reduce((acc, key) => {
+      acc[key] = true;
+      return acc;
+    }, {}),
+  };
+
+  postMessage({ type: 'SANDBOX_READY', result });
 }
 
 function onMessage({ source, data }) {


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: https://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:
It's a long story, that is partially explained in https://github.com/testing-library/testing-playground/issues/255#issuecomment-665515025, but long story short, we have multiple sources where we evaluate the query against the markup.

This pull-request changes that. The in-memory frame still feels like the best theoretical solution to me, but evaluating in the visible iframe, is the more practical solution.

I've removed the `runInSandbox` method from the parser. We now always use `runUnsafe` (in the DOM, against a visual element).
 
<!-- Why are these changes necessary? -->

**Why**:
Because the query results in an in-memory iframe differ from the results in a visible iframe.

<!-- How were these changes implemented? -->

**How**:
![image](https://user-images.githubusercontent.com/1196524/88785742-de675b00-d191-11ea-9187-72d1dc8d50a9.png)


<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
---

fixes #255 