### PR TITLE
fix: prevent sandbox update when clicking elements in sandbox

### DIFF
--- a/devtools/src/devtools/panel.js
+++ b/devtools/src/devtools/panel.js
@@ -32,7 +32,7 @@ function Panel() {
             setResult(result);
           });
 
-          if (action.updateEditor !== false) {
+          if (action.origin !== 'EDITOR') {
             editor.current.setValue(action.query);
           }
           break;

--- a/src/components/MarkupEditor.js
+++ b/src/components/MarkupEditor.js
@@ -14,7 +14,7 @@ function MarkupEditor({ markup, dispatch }) {
       dispatch({
         type: 'SET_MARKUP',
         markup,
-        updateEditor: false,
+        origin: 'EDITOR',
         immediate: origin === 'user',
       }),
     [dispatch],

--- a/src/components/Preview.js
+++ b/src/components/Preview.js
@@ -66,7 +66,11 @@ function Preview({ markup, variant, forwardedRef, dispatch }) {
         }
 
         case 'SELECT_NODE': {
-          dispatch({ type: 'SET_QUERY', query: suggestion.snippet });
+          dispatch({
+            type: 'SET_QUERY',
+            query: suggestion.snippet,
+            origin: 'SANDBOX',
+          });
           break;
         }
 

--- a/src/components/QueryEditor.js
+++ b/src/components/QueryEditor.js
@@ -14,7 +14,7 @@ function QueryEditor(props) {
       dispatch({
         type: 'SET_QUERY',
         query,
-        updateEditor: false,
+        origin: 'EDITOR',
         immediate: origin === 'user',
       }),
     [dispatch],

--- a/src/hooks/usePlayground.js
+++ b/src/hooks/usePlayground.js
@@ -52,7 +52,7 @@ function reducer(state, action, exec) {
     }
 
     case 'SET_MARKUP': {
-      if (action.updateEditor !== false) {
+      if (action.origin !== 'EDITOR') {
         exec({ type: 'UPDATE_EDITOR', editor: 'markup' });
       }
 
@@ -66,7 +66,7 @@ function reducer(state, action, exec) {
     }
 
     case 'SET_QUERY': {
-      if (action.updateEditor !== false) {
+      if (action.origin !== 'EDITOR') {
         exec({ type: 'UPDATE_EDITOR', editor: 'query' });
       }
 

--- a/src/hooks/usePlayground.js
+++ b/src/hooks/usePlayground.js
@@ -70,7 +70,9 @@ function reducer(state, action, exec) {
         exec({ type: 'UPDATE_EDITOR', editor: 'query' });
       }
 
-      exec({ type: 'UPDATE_SANDBOX', immediate });
+      if (action.origin !== 'SANDBOX') {
+        exec({ type: 'UPDATE_SANDBOX', immediate });
+      }
 
       return {
         ...state,

--- a/src/sandbox.js
+++ b/src/sandbox.js
@@ -117,6 +117,12 @@ function onSelectNode(node, { origin }) {
     cssPath: cssPath(node, true).toString(),
   };
 
+  if (action.type === 'SELECT_NODE') {
+    // optimistically update the highlighted node
+    state.queriedNodes = [node];
+    state.highlighter.highlight({ nodes: state.queriedNodes });
+  }
+
   postMessage(action);
 }
 


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: https://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:
This fixes the issue where selecting an `input` in the `sandbox`, causes a direct update of that same sandbox. The problem with that is that whatever is being typed in an `input`, is directly being undone.

<!-- Why are these changes necessary? -->

**Why**:
Because not being able to type in inputs, is highly frustrating.

<!-- How were these changes implemented? -->

**How**:
Let the `state reducer` know that it's the `sandbox` that caused the update, so that it can skip the `sandbox update` effect.

Sandbox only updates the query, in a way that results to the same element selection. So we can skip a round trip, and highlight the element directly from within the sandbox.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
