### PR TITLE
feat: prevent opening links, unless ctrl or shift clicked

### DIFF
--- a/src/sandbox.js
+++ b/src/sandbox.js
@@ -60,6 +60,14 @@ function setInnerHTML(node, html) {
     newScript.appendChild(doc.createTextNode(text));
     prevScript.parentNode.replaceChild(newScript, prevScript);
   }
+
+  for (let anchor of node.querySelectorAll('a')) {
+    anchor.addEventListener('click', (e) => {
+      if (!e.ctrlKey && !e.shiftKey) {
+        e.preventDefault();
+      }
+    });
+  }
 }
 
 function Sandbox() {


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: https://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:
Prevent `<a href="` elements from opening links when being clicked.

<!-- Why are these changes necessary? -->

**Why**:
It's frustrating that a click on `a` elements open a page when all we want is to have that selector.

<!-- How were these changes implemented? -->

**How**:
Prevent the click action, unless either `ctrl` or `shift` is being pressed as well. `ctrl+click` usually opens in a new tab, and `shift+click` opens in a new window. Both are explicit user actions, and thereby fine.
 
<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
