### PR TITLE
feat: hide app name on small screens

### DIFF
--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -48,7 +48,7 @@ function Header({
                 src={icon}
                 alt="Testing Playground mascot Froggy"
               />
-              ️ <span>Testing Playground</span>
+              ️ <span className="hidden sm:block">Testing Playground</span>
             </h1>
           </a>
         </div>


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: https://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:
hide the `Testing Playground` title on small screens

<!-- Why are these changes necessary? -->

**Why**:
Because the title is long, and pushes the `⋮` menu off screen.

<!-- How were these changes implemented? -->

**How**:
Tailwind `className="hidden sm:block"` :sunglasses: 
<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
