### PR TITLE
feat: support saving with partial content

### DIFF
--- a/src/lambda/gist/gist.js
+++ b/src/lambda/gist/gist.js
@@ -52,6 +52,22 @@ async function getGist({ id, version }) {
   return { id, version, files };
 }
 
+const placeholderValues = {
+  js: '// your query',
+  html: '<!-- your markup -->',
+  json: '{}',
+};
+
+function ensureContent(files) {
+  for (let name of Object.keys(files)) {
+    if (files[name].content.length === 0) {
+      files[name].content = placeholderValues[name.split('.').pop()] || 'o.O';
+    }
+  }
+
+  return files;
+}
+
 /**
  * @param id {string}
  * @param description {string}
@@ -59,6 +75,9 @@ async function getGist({ id, version }) {
  * @returns {Promise<{id: *, version: *, url: string}>}
  */
 async function saveGist({ id, description, files }) {
+  // we can't save empty files to github gists. So we'll make sure they ain't empty.
+  ensureContent(files);
+
   // if the id is given, we assume an update and thereby just correct the method.
   const response = await fetch([ENDPOINT, id].filter(Boolean).join('/'), {
     method: id ? 'PATCH' : 'POST',


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: https://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:
Support saving markup-only playgrounds (without query).

<!-- Why are these changes necessary? -->

**Why**:
Sometimes people don't know what query to use. To get feedback on based on their markup alone, it would be nice to be able to save a playground without queries. This also allows for easy third party integrations.

<!-- How were these changes implemented? -->

**How**:
Before posting the data to github, we now set the query to `// your query` and the markup to `<!-- your markup -->` if they aren't provided. I've tried just submitting some whitespace or newlines. But GitHub ain't easy to fool.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
