### PR TITLE
feat: auto save on share

### DIFF
--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -92,13 +92,18 @@ function Header({
 
               <Modal>
                 <ModalOpenButton>
-                  <MenuLink as="button" disabled={!gistId}>
+                  <MenuLink as="button">
                     <ShareAndroidIcon size={12} />
                     <span>Share</span>
                   </MenuLink>
                 </ModalOpenButton>
                 <ModalContents>
-                  <Share dirty={dirty} />
+                  <Share
+                    dirty={dirty}
+                    dispatch={dispatch}
+                    gistId={gistId}
+                    gistVersion={gistVersion}
+                  />
                 </ModalContents>
               </Modal>
 

--- a/src/components/Share.js
+++ b/src/components/Share.js
@@ -1,26 +1,41 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import Input from './Input';
 import CopyButton from './CopyButton';
+import { SyncIcon } from '@primer/octicons-react';
 
-function Share({ dirty }) {
+function Share({ dirty, dispatch, gistId, gistVersion }) {
+  useEffect(() => {
+    if (!dirty) {
+      return;
+    }
+
+    dispatch({ type: 'SAVE' });
+  }, [dirty, gistId, dispatch]);
+
+  // it is possible to have a clean state, and still no gistId. This happens
+  // on either empty playgrounds, or when using statefull urls.
+  const shareUrl = gistId
+    ? [location.origin, 'gist', gistId, gistVersion].filter(Boolean).join('/')
+    : location.href;
+
+  console.log('share url');
   return (
     <div className="settings text-sm pb-2">
       <div>
         <h3 className="text-sm font-bold mb-2">Share</h3>
 
-        {dirty && (
-          <div className="bg-blue-100 p-2 text-xs rounded my-2 text-blue-800">
-            Please note that this playground has
-            <strong> unsaved changes </strong>. The link below
-            <strong> will not include </strong> your latest changes!
+        <label className="text-xs">playground link:</label>
+        {dirty ? (
+          <div className="flex space-x-4 items-center border rounded w-full py-2 px-3 bg-white text-gray-800 leading-tight">
+            <SyncIcon size={12} className="spinner" />
+            <span>one sec...</span>
+          </div>
+        ) : (
+          <div className="flex space-x-4">
+            <Input key={shareUrl} defaultValue={shareUrl} readOnly name="url" />
+            <CopyButton text={shareUrl} />
           </div>
         )}
-
-        <label className="text-xs">playground link:</label>
-        <div className="flex space-x-4">
-          <Input defaultValue={window.location.href} name="url" />
-          <CopyButton text={window.location.href} />
-        </div>
       </div>
     </div>
   );

--- a/src/hooks/usePlayground.js
+++ b/src/hooks/usePlayground.js
@@ -122,7 +122,6 @@ function reducer(state, action, exec) {
 
       return {
         ...state,
-        dirty: false,
         status: 'saving',
       };
     }
@@ -132,8 +131,15 @@ function reducer(state, action, exec) {
 
       return {
         ...state,
-        dirty: false,
         status: 'saving',
+      };
+    }
+
+    case 'SAVED': {
+      return {
+        ...state,
+        dirty: false,
+        status: 'idle',
       };
     }
 
@@ -230,7 +236,7 @@ const effectMap = {
     });
 
     history.push(`/gist/${id}/${version}`);
-    dispatch({ type: 'SET_STATUS', status: 'idle' });
+    dispatch({ type: 'SAVED' });
   },
 
   FORK: async (state, effect, dispatch) => {
@@ -244,7 +250,7 @@ const effectMap = {
     });
 
     history.push(`/gist/${id}/${version}`);
-    dispatch({ type: 'SET_STATUS', status: 'idle' });
+    dispatch({ type: 'SAVED' });
   },
 
   REDIRECT: (state, effect) => {


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: https://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:
Instead of showing a message: `this share url doesn't reflect the current state!!111`, we now make sure that it does.

<!-- Why are these changes necessary? -->

**Why**:
Till now, we were warning the user when they try get a share link for an unsaved playground. Why not just save it for them though? In 99% of all cases, users want to share the current state.
 
<!-- How were these changes implemented? -->

**How**:
When the share modal opens, it's checking for a `dirty state`. When that's the case, it will render a spinner, and trigger the save action. Once the playground has been saved, it will render the share url.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
