### PR TITLE
fix(oEmbed): Bring iframe in line with the embed in the GUI

### DIFF
--- a/src/lambda/oembed/oembed.js
+++ b/src/lambda/oembed/oembed.js
@@ -35,6 +35,7 @@ function handler(event, context, callback) {
   }
 
   const { url, referrer, maxwidth = 900, maxheight = 300 } = params;
+  const iframeSrc = `${url.replace('gist', 'embed')}?panes=preview,result`;
 
   callback(null, {
     statusCode: 200,
@@ -47,7 +48,7 @@ function handler(event, context, callback) {
         provider_name: 'testing-playground.com',
         provider_url: host,
 
-        html: `<iframe src="${url}" width="${maxwidth}" height="${maxheight}" scrolling="no" frameborder="0" allowtransparency="true" allowfullscreen="true" title="Testing Playground" style="overflow: hidden; display: block;" loading="lazy" name="testing-playground-${Date.now()}"></iframe>`,
+        html: `<iframe src="${iframeSrc}" height="${maxheight}" width="${maxwidth}" scrolling="no" frameBorder="0" allowTransparency="true" title="Testing Playground" style="overflow: hidden; display: block; width: 100%"></iframe>`,
         width: maxwidth,
         height: maxheight,
 


### PR DESCRIPTION
Just like you have at
https://github.com/testing-library/testing-playground/blob/dc14e4ae6430876cdb0a36fda09486fdb3ae6d93/src/components/Embed.js#L37