### PR TITLE
feat: change default panes for embed mode to query,preview

### DIFF
--- a/src/components/Embedded.js
+++ b/src/components/Embedded.js
@@ -46,7 +46,7 @@ function Embedded(props) {
         .split(',')
         .map((x) => x.trim())
         .filter((x) => SUPPORTED_PANES[x])
-    : ['markup', 'preview', 'query', 'result'];
+    : ['query', 'preview'];
 
   // TODO: we should add tabs to handle > 2 panes
   const areaCount = panes.length;


### PR DESCRIPTION
The embedded version renders all panes next to each other in a row. Four panes, is really to much. So I defaulted it to `query` and `preview`.

It can still be configured by providing the `panes=markup,query,result,preview` query param.