### PR TITLE
feat: add url validation to oembed

### DIFF
--- a/src/lambda/server/server.js
+++ b/src/lambda/server/server.js
@@ -25,11 +25,8 @@ function handler(event, context, callback) {
   const host = getHostname(event, context);
 
   const embedPath = event.path.replace('/gist/', '/embed/');
-  const frameSrc = `${host}${embedPath}?${queryString.stringify({
-    panes,
-    markup,
-    query,
-  })}`;
+  const frameSearch = queryString.stringify({ panes, markup, query });
+  const frameSrc = host + embedPath + (frameSearch ? `?${frameSearch}` : '');
 
   const oembedSearch = queryString.stringify({ url: frameSrc });
 


### PR DESCRIPTION
We now validate the oembed url, and we correct it if the consumer provides a wrong playground url.

To get the oembed url, the consumer should retrieve it from the HTML. But it turns out not every consumer does this. Some figure out where we host the `oembed` api, and call that directly. Resulting in incorrect embed urls.

We can't do everything to support those consumers, but we now do replace the `/gist/` path with a `/embed/` to be a bit less strict.