### PR TITLE
chore: use global URL instead of import

### DIFF
--- a/package.json
+++ b/package.json
@@ -118,5 +118,8 @@
     "hooks": {
       "pre-commit": "lint-staged"
     }
+  },
+  "engines": {
+    "node": ">=10.15.3"
   }
 }

--- a/src/lambda/oembed/oembed.js
+++ b/src/lambda/oembed/oembed.js
@@ -1,5 +1,3 @@
-const URL = require('url');
-
 function incorrectParams(error) {
   return {
     statusCode: 501, // oembed status // 422, // Unprocessable Entity
@@ -40,7 +38,7 @@ function handler(event, context, callback) {
     );
   }
 
-  const { hostname, pathname } = URL.parse(params.url);
+  const { hostname, pathname } = new URL(params.url);
 
   // verify if the url is supported, basically we only allow localhost if we're
   // running at localhost, and testing-playground.com as host. And either no


### PR DESCRIPTION
Remove `const URL = require('url');` line, because `url.parse` is [deprecated](https://nodejs.org/api/url.html#url_url_parse_urlstring_parsequerystring_slashesdenotehost) and `URL` is globally available [since Node 10](https://nodejs.org/api/globals.html#globals_url).

I also added the `engines` key to the `package.json` to make it clear that this project needs to be run on Node 10 as [`memoize-one`](https://github.com/alexreardon/memoize-one) needs it
https://github.com/alexreardon/memoize-one/blob/c7994d25b614531c7ccfd30cc34d49385e3fa678/package.json#L90