### PR TITLE
feat: add tabs to switch between query and event mode

### DIFF
--- a/src/components/App.js
+++ b/src/components/App.js
@@ -2,19 +2,20 @@ import React from 'react';
 import { BrowserRouter as Router, Switch, Route } from 'react-router-dom';
 import Playground from './Playground';
 import Embedded from './Embedded';
-import DomEvents from './DomEvents';
+import { PreviewEventsProvider } from '../context/PreviewEvents';
 
 function App() {
   return (
     <Router>
-      <Switch>
-        <Route path="/embed/:gistId?/:gistVersion?" component={Embedded} />
-        <Route path="/events" component={DomEvents} />
-        <Route
-          path={['/gist/:gistId/:gistVersion?', '/']}
-          component={Playground}
-        />
-      </Switch>
+      <PreviewEventsProvider>
+        <Switch>
+          <Route path="/embed/:gistId?/:gistVersion?" component={Embedded} />
+          <Route
+            path={['/gist/:gistId/:gistVersion?', '/']}
+            component={Playground}
+          />
+        </Switch>
+      </PreviewEventsProvider>
     </Router>
   );
 }

--- a/src/components/DomEvents.js
+++ b/src/components/DomEvents.js
@@ -1,84 +1,18 @@
-import React, { useRef, useCallback, useState } from 'react';
-import { eventMap } from '@testing-library/dom/dist/event-map';
+import React, { useRef } from 'react';
 import { ChevronUpIcon, ChevronDownIcon } from '@primer/octicons-react';
-import throttle from 'lodash.throttle';
+
 import AutoSizer from 'react-virtualized-auto-sizer';
 import { TrashcanIcon } from '@primer/octicons-react';
 
-import Preview from './Preview';
-import MarkupEditor from './MarkupEditor';
-import usePlayground from '../hooks/usePlayground';
 import { VirtualScrollable } from './Scrollable';
 import IconButton from './IconButton';
 import CopyButton from './CopyButton';
 import EmptyStreetImg from '../images/EmptyStreetImg';
 import StickyList from './StickyList';
-import Layout from './Layout';
-import { useParams } from 'react-router-dom';
-
-function targetToString() {
-  return [
-    this.tagName.toLowerCase(),
-    this.id && `#${this.id}`,
-    this.name && `[name="${this.name}"]`,
-    this.htmlFor && `[for="${this.htmlFor}"]`,
-    this.value && `[value="${this.value}"]`,
-    this.checked !== null && `[checked=${this.checked}]`,
-  ]
-    .filter(Boolean)
-    .join('');
-}
-
-function getElementData(element) {
-  const value =
-    element.tagName === 'SELECT' && element.multiple
-      ? element.selectedOptions.length > 0
-        ? JSON.stringify(
-            Array.from(element.selectedOptions).map((o) => o.value),
-          )
-        : null
-      : element.value;
-
-  const hasChecked = element.type === 'checkbox' || element.type === 'radio';
-
-  return {
-    tagName: element.tagName.toLowerCase(),
-    id: element.id || null,
-    name: element.name || null,
-    htmlFor: element.htmlFor || null,
-    value: value || null,
-    checked: hasChecked ? !!element.checked : null,
-    toString: targetToString,
-  };
-}
-
-function addLoggingEvents(node, log) {
-  function createEventLogger(eventType) {
-    return function logEvent(event) {
-      if (event.target === event.currentTarget) {
-        return;
-      }
-
-      log({
-        event: eventType,
-        target: getElementData(event.target),
-      });
-    };
-  }
-  const eventListeners = [];
-  Object.keys(eventMap).forEach((name) => {
-    eventListeners.push({
-      name: name.toLowerCase(),
-      listener: node.addEventListener(
-        name.toLowerCase(),
-        createEventLogger({ name, ...eventMap[name] }),
-        true,
-      ),
-    });
-  });
-
-  return eventListeners;
-}
+import {
+  usePreviewEvents,
+  usePreviewEventsActions,
+} from '../context/PreviewEvents';
 
 function EventRecord({ index, style, data }) {
   const { id, type, name, element, selector } = data[index];
@@ -102,19 +36,9 @@ function EventRecord({ index, style, data }) {
 }
 
 function DomEvents() {
-  const { gistId, gistVersion } = useParams();
-
-  const buffer = useRef([]);
-  const previewRef = useRef();
   const listRef = useRef();
-
-  const sortDirection = useRef('asc');
-  const [appendMode, setAppendMode] = useState('bottom');
-  const [state, dispatch] = usePlayground({ gistId, gistVersion });
-  const { markup, result, status, dirty, settings } = state;
-
-  const [eventCount, setEventCount] = useState(0);
-  const [eventListeners, setEventListeners] = useState([]);
+  const { sortDirection, buffer, appendMode, eventCount } = usePreviewEvents();
+  const { changeSortDirection, reset } = usePreviewEventsActions();
 
   const getSortIcon = () => (
     <IconButton>
@@ -126,143 +50,67 @@ function DomEvents() {
     </IconButton>
   );
 
-  const changeSortDirection = () => {
-    const newDirection = sortDirection.current === 'desc' ? 'asc' : 'desc';
-    buffer.current = buffer.current.reverse();
-    setAppendMode(newDirection === 'desc' ? 'top' : 'bottom');
-    sortDirection.current = newDirection;
-  };
-
-  const reset = () => {
-    buffer.current = [];
-    setEventCount(0);
-  };
-
   const getTextToCopy = () =>
     buffer.current
       .map((log) => `${log.target.toString()} - ${log.event.EventType}`)
       .join('\n');
 
-  const flush = useCallback(
-    throttle(() => setEventCount(buffer.current.length), 16, {
-      leading: false,
-    }),
-    [setEventCount],
-  );
-
-  const setPreviewRef = useCallback((node) => {
-    if (node) {
-      previewRef.current = node;
-      const eventListeners = addLoggingEvents(node, (event) => {
-        const log = {
-          id: buffer.current.length + 1,
-          type: event.event.EventType,
-          name: event.event.name,
-          element: event.target.tagName,
-          selector: event.target.toString(),
-        };
-        if (sortDirection.current === 'desc') {
-          buffer.current.splice(0, 0, log);
-        } else {
-          buffer.current.push(log);
-        }
-
-        setTimeout(flush, 0);
-      });
-      setEventListeners(eventListeners);
-    } else if (previewRef.current) {
-      eventListeners.forEach((event) =>
-        previewRef.current.removeEventListener(event.name, event.listener),
-      );
-      previewRef.current = null;
-    }
-  }, []);
-
   return (
-    <Layout
-      dispatch={dispatch}
-      gistId={gistId}
-      dirty={dirty}
-      status={status}
-      settings={settings}
-    >
-      <div className="flex flex-col h-auto md:h-full w-full">
-        <div className="editor p-4 markup-editor gap-4 md:gap-8 md:h-56 flex-auto grid-cols-1 md:grid-cols-2">
-          <div className="flex-auto relative h-56 md:h-full">
-            <MarkupEditor markup={markup} dispatch={dispatch} />
+    <div className="editor p-4 h-56 flex-auto overflow-hidden">
+      <div className="h-full w-full flex flex-col">
+        <div className="h-8 flex items-center w-full text-sm font-bold">
+          <div
+            className="p-2 w-16 cursor-pointer flex justify-between items-center"
+            onClick={changeSortDirection}
+          >
+            # {getSortIcon()}
           </div>
 
-          <div className="flex-auto h-56 md:h-full">
-            <Preview
-              forwardedRef={setPreviewRef}
-              markup={markup}
-              elements={result?.elements}
-              accessibleRoles={result?.accessibleRoles}
-              dispatch={dispatch}
-              variant="minimal"
-            />
+          <div className="p-2 w-32 ">type</div>
+          <div className="p-2 w-32 ">name</div>
+
+          <div className="p-2 w-40 ">element</div>
+          <div className="flex-auto p-2 flex justify-between">
+            <span>selector</span>
+            <div>
+              <CopyButton
+                text={getTextToCopy}
+                title="copy log"
+                className="mr-5"
+              />
+              <IconButton title="clear event log" onClick={reset}>
+                <TrashcanIcon />
+              </IconButton>
+            </div>
           </div>
         </div>
 
-        <div className="flex-none h-8" />
-
-        <div className="editor p-4 md:h-56 flex-auto overflow-hidden">
-          <div className="h-56 md:h-full w-full flex flex-col">
-            <div className="h-8 flex items-center w-full text-sm font-bold">
-              <div
-                className="p-2 w-16 cursor-pointer flex justify-between items-center"
-                onClick={changeSortDirection}
-              >
-                # {getSortIcon()}
-              </div>
-
-              <div className="p-2 w-32 ">type</div>
-              <div className="p-2 w-32 ">name</div>
-
-              <div className="p-2 w-40 ">element</div>
-              <div className="flex-auto p-2 flex justify-between">
-                <span>selector</span>
-                <div>
-                  <CopyButton
-                    text={getTextToCopy}
-                    title="copy log"
-                    className="mr-5"
-                  />
-                  <IconButton title="clear event log" onClick={reset}>
-                    <TrashcanIcon />
-                  </IconButton>
-                </div>
-              </div>
+        <div className="flex-auto relative overflow-hidden">
+          {buffer.current.length === 0 ? (
+            <div className="flex w-full h-full opacity-50 items-end justify-center">
+              <EmptyStreetImg height="80%" />
             </div>
-
-            <div className="flex-auto relative overflow-hidden">
-              {buffer.current.length === 0 ? (
-                <div className="flex w-full h-full opacity-50 items-end justify-center">
-                  <EmptyStreetImg height="80%" />
-                </div>
-              ) : (
-                <AutoSizer>
-                  {({ width, height }) => (
-                    <StickyList
-                      mode={appendMode}
-                      ref={listRef}
-                      height={height}
-                      itemCount={eventCount}
-                      itemData={buffer.current}
-                      itemSize={32}
-                      width={width}
-                      outerElementType={VirtualScrollable}
-                    >
-                      {EventRecord}
-                    </StickyList>
-                  )}
-                </AutoSizer>
+          ) : (
+            <AutoSizer>
+              {({ width, height }) => (
+                <StickyList
+                  mode={appendMode}
+                  ref={listRef}
+                  height={height}
+                  itemCount={eventCount}
+                  itemData={buffer.current}
+                  itemSize={32}
+                  width={width}
+                  outerElementType={VirtualScrollable}
+                >
+                  {EventRecord}
+                </StickyList>
               )}
-            </div>
-          </div>
+            </AutoSizer>
+          )}
         </div>
       </div>
-    </Layout>
+    </div>
   );
 }
 

--- a/src/components/Embed.js
+++ b/src/components/Embed.js
@@ -5,24 +5,7 @@ import Embedded from './Embedded';
 import { SyncIcon, XIcon } from '@primer/octicons-react';
 
 import { defaultPanes } from '../constants';
-
-function TabButton({ children, active, onClick, disabled }) {
-  return (
-    <button
-      disabled={disabled}
-      className={[
-        'text-xs select-none border-b-2',
-        disabled ? '' : 'hover:text-blue-400 hover:border-blue-400',
-        active
-          ? 'border-blue-600 text-blue-600'
-          : 'border-transparent text-gray-800',
-      ].join(' ')}
-      onClick={disabled ? undefined : onClick}
-    >
-      {children}
-    </button>
-  );
-}
+import TabButton from './TabButton';
 
 const possiblePanes = ['markup', 'preview', 'query', 'result'];
 

--- a/src/components/Loader.js
+++ b/src/components/Loader.js
@@ -6,7 +6,7 @@ function Loader({ loading }) {
     <div
       className={[
         'w-full h-full absolute top-0 left-0 flex flex-col justify-center items-center w-full h-full space-y-4 fade',
-        loading ? 'opacity-100' : 'opacity-0',
+        loading ? 'opacity-100' : 'hidden opacity-0',
       ].join(' ')}
     >
       <img className="opacity-50" src={frog} />

--- a/src/components/Playground.js
+++ b/src/components/Playground.js
@@ -2,24 +2,17 @@ import React from 'react';
 import { useParams } from 'react-router-dom';
 import Preview from './Preview';
 import MarkupEditor from './MarkupEditor';
-import Result from './Result';
-import Query from './Query';
 import usePlayground from '../hooks/usePlayground';
 import Layout from './Layout';
 import Loader from './Loader';
-
-function Paper({ children }) {
-  return (
-    <div className="editor p-4 gap-4 md:gap-8 md:h-56 flex-auto grid-cols-1 md:grid-cols-2">
-      {children}
-    </div>
-  );
-}
+import PlaygroundPanels from './PlaygroundPanels';
+import { usePreviewEvents } from '../context/PreviewEvents';
 
 function Playground() {
   const { gistId, gistVersion } = useParams();
   const [state, dispatch] = usePlayground({ gistId, gistVersion });
-  const { markup, query, result, status, dirty, settings } = state;
+  const { markup, result, status, dirty, settings } = state;
+  const { previewRef } = usePreviewEvents();
 
   const isLoading = status === 'loading';
 
@@ -39,32 +32,24 @@ function Playground() {
           isLoading ? 'opacity-0' : 'opacity-100',
         ].join(' ')}
       >
-        <Paper>
+        <div className="editor p-4 gap-4 md:gap-8 md:h-56 flex-auto grid-cols-1 md:grid-cols-2">
           <div className="flex-auto relative h-56 md:h-full">
             <MarkupEditor markup={markup} dispatch={dispatch} />
           </div>
 
           <div className="flex-auto h-56 md:h-full">
             <Preview
+              forwardedRef={previewRef}
               markup={markup}
               elements={result?.elements}
               accessibleRoles={result?.accessibleRoles}
               dispatch={dispatch}
             />
           </div>
-        </Paper>
+        </div>
 
-        <div className="flex-none h-8" />
-
-        <Paper>
-          <div className="flex-auto relative h-56 md:h-full">
-            <Query query={query} result={result} dispatch={dispatch} />
-          </div>
-
-          <div className="flex-auto h-56 md:h-full overflow-hidden">
-            <Result result={result} dispatch={dispatch} />
-          </div>
-        </Paper>
+        <div className="flex-none h-3" />
+        <PlaygroundPanels />
       </div>
     </Layout>
   );

--- a/src/components/PlaygroundPanels.js
+++ b/src/components/PlaygroundPanels.js
@@ -1,0 +1,63 @@
+import React, { Suspense } from 'react';
+import { useState } from 'react';
+import { useParams } from 'react-router-dom';
+
+import usePlayground from '../hooks/usePlayground';
+
+import Query from './Query';
+import Result from './Result';
+import TabButton from './TabButton';
+
+const panels = ['Query', 'Events'];
+
+const DomEvents = React.lazy(() => import('./DomEvents'));
+
+function Paper({ children }) {
+  return (
+    <div className="editor p-4 gap-4 md:gap-8 md:h-56 flex-auto grid-cols-1 md:grid-cols-2">
+      {children}
+    </div>
+  );
+}
+
+function PlaygroundPanels() {
+  const { gistId, gistVersion } = useParams();
+  const [state, dispatch] = usePlayground({ gistId, gistVersion });
+  const { query, result } = state;
+  const [panel, setPanel] = useState(panels[0]);
+
+  return (
+    <>
+      <div className="px-4 gap-4 flex py-2">
+        {panels.map((panelName) => (
+          <div key={panelName} className="flex items-center">
+            <div className="text-left space-x-2">
+              <TabButton
+                onClick={() => setPanel(panelName)}
+                active={panelName === panel}
+              >
+                {panelName}
+              </TabButton>
+            </div>
+          </div>
+        ))}
+      </div>
+      <Suspense fallback={null}>
+        {panel === panels[0] && (
+          <Paper>
+            <div className="flex-auto relative h-56 md:h-full">
+              <Query query={query} result={result} dispatch={dispatch} />
+            </div>
+
+            <div className="flex-auto h-56 md:h-full overflow-hidden">
+              <Result result={result} dispatch={dispatch} />
+            </div>
+          </Paper>
+        )}
+        {panel === panels[1] && <DomEvents />}
+      </Suspense>
+    </>
+  );
+}
+
+export default PlaygroundPanels;

--- a/src/components/TabButton.js
+++ b/src/components/TabButton.js
@@ -1,0 +1,21 @@
+import React from 'react';
+
+function TabButton({ children, active, onClick, disabled }) {
+  return (
+    <button
+      disabled={disabled}
+      className={[
+        'text-xs select-none border-b-2',
+        disabled ? '' : 'hover:text-blue-400 hover:border-blue-400',
+        active
+          ? 'border-blue-600 text-blue-600'
+          : 'border-transparent text-gray-800',
+      ].join(' ')}
+      onClick={disabled ? undefined : onClick}
+    >
+      {children}
+    </button>
+  );
+}
+
+export default TabButton;

--- a/src/context/PreviewEvents.js
+++ b/src/context/PreviewEvents.js
@@ -1,0 +1,113 @@
+import React, {
+  useCallback,
+  useRef,
+  useState,
+  useContext,
+  createContext,
+} from 'react';
+import throttle from 'lodash.throttle';
+
+import { addLoggingEvents } from '../lib/domEvents';
+
+const PreviewEventsContext = createContext();
+const PreviewEventsActionsContext = createContext();
+
+export function PreviewEventsProvider({ children }) {
+  const buffer = useRef([]);
+  const previewRef = useRef();
+  const sortDirection = useRef('asc');
+  const [appendMode, setAppendMode] = useState('bottom');
+  const [eventCount, setEventCount] = useState(0);
+  const [eventListeners, setEventListeners] = useState([]);
+
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  const flush = useCallback(
+    throttle(() => setEventCount(buffer.current.length), 16, {
+      leading: false,
+    }),
+    [setEventCount],
+  );
+
+  const changeSortDirection = () => {
+    const newDirection = sortDirection.current === 'desc' ? 'asc' : 'desc';
+    buffer.current = buffer.current.reverse();
+    setAppendMode(newDirection === 'desc' ? 'top' : 'bottom');
+    sortDirection.current = newDirection;
+  };
+
+  const reset = () => {
+    buffer.current = [];
+    setEventCount(0);
+  };
+
+  const setPreviewRef = useCallback((node) => {
+    if (node) {
+      previewRef.current = node;
+      const eventListeners = addLoggingEvents(node, (event) => {
+        const log = {
+          id: buffer.current.length + 1,
+          type: event.event.EventType,
+          name: event.event.name,
+          element: event.target.tagName,
+          selector: event.target.toString(),
+        };
+        if (sortDirection.current === 'desc') {
+          buffer.current.splice(0, 0, log);
+        } else {
+          buffer.current.push(log);
+        }
+
+        setTimeout(flush, 0);
+      });
+      setEventListeners(eventListeners);
+    } else if (previewRef.current) {
+      eventListeners.forEach((event) =>
+        previewRef.current.removeEventListener(event.name, event.listener),
+      );
+      previewRef.current = null;
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  return (
+    <PreviewEventsContext.Provider
+      value={{
+        previewRef: setPreviewRef,
+        appendMode,
+        eventCount,
+        buffer,
+        sortDirection,
+      }}
+    >
+      <PreviewEventsActionsContext.Provider
+        value={{ changeSortDirection, reset }}
+      >
+        {children}
+      </PreviewEventsActionsContext.Provider>
+    </PreviewEventsContext.Provider>
+  );
+}
+
+export function usePreviewEvents() {
+  const context = useContext(PreviewEventsContext);
+
+  if (!context) {
+    throw new Error(
+      `usePreviewEvents must be used within PreviewEventsProvider`,
+    );
+  }
+
+  return context;
+}
+
+export function usePreviewEventsActions() {
+  const context = useContext(PreviewEventsActionsContext);
+
+  if (!context) {
+    throw new Error(
+      `usePreviewEventsActions must be used within PreviewEventsProvider`,
+    );
+  }
+
+  return context;
+}

--- a/src/lib/domEvents.js
+++ b/src/lib/domEvents.js
@@ -1,0 +1,65 @@
+import { eventMap } from '@testing-library/dom/dist/event-map';
+
+export function addLoggingEvents(node, log) {
+  function createEventLogger(eventType) {
+    return function logEvent(event) {
+      if (event.target === event.currentTarget) {
+        return;
+      }
+
+      log({
+        event: eventType,
+        target: getElementData(event.target),
+      });
+    };
+  }
+  const eventListeners = [];
+  Object.keys(eventMap).forEach((name) => {
+    eventListeners.push({
+      name: name.toLowerCase(),
+      listener: node.addEventListener(
+        name.toLowerCase(),
+        createEventLogger({ name, ...eventMap[name] }),
+        true,
+      ),
+    });
+  });
+
+  return eventListeners;
+}
+
+export function getElementData(element) {
+  const value =
+    element.tagName === 'SELECT' && element.multiple
+      ? element.selectedOptions.length > 0
+        ? JSON.stringify(
+            Array.from(element.selectedOptions).map((o) => o.value),
+          )
+        : null
+      : element.value;
+
+  const hasChecked = element.type === 'checkbox' || element.type === 'radio';
+
+  return {
+    tagName: element.tagName.toLowerCase(),
+    id: element.id || null,
+    name: element.name || null,
+    htmlFor: element.htmlFor || null,
+    value: value || null,
+    checked: hasChecked ? !!element.checked : null,
+    toString: targetToString,
+  };
+}
+
+export function targetToString() {
+  return [
+    this.tagName.toLowerCase(),
+    this.id && `#${this.id}`,
+    this.name && `[name="${this.name}"]`,
+    this.htmlFor && `[for="${this.htmlFor}"]`,
+    this.value && `[value="${this.value}"]`,
+    this.checked !== null && `[checked=${this.checked}]`,
+  ]
+    .filter(Boolean)
+    .join('');
+}


### PR DESCRIPTION
**What**:

This PR fixes #172 and merge the `/events` route with the playground, showing the two views together and making it possible for the user to switch between them.

<img width="1214" alt="Screenshot 2020-11-13 at 12 52 13" src="https://user-images.githubusercontent.com/922348/99074116-14004a80-25af-11eb-98ef-0b15b01316c4.png">

**Why**:

Required from #172 in which we wanted a way to switch between views.

**How**:

* Extracted `TabButton` to be used from `Embed` and the new view.
* Created a new component called `PlaygroundPanels`
* Moved the bottom part of `DomEvents` view into `PlaygroundPanels`
* Moved the bottom part of `Playground` into `PlaygroundPanels`
* Refactor functionality of `DomEvents` into a context, so we are able to get the correct `ref` for the `Preview`
* Extracted `DomEvent` dom utilities into separate file.

**Checklist**:

- [ ] Tests N/A
- [x] Ready to be merged
