### PR TITLE
fix: persist cursor position on paste

### DIFF
--- a/src/components/Editor.js
+++ b/src/components/Editor.js
@@ -184,6 +184,12 @@ function handleChange(cm, change) {
     case 'paste': {
       formatValue(cm);
       cm.onChange(cm.getValue(), { origin: change.origin });
+      const text = change.text;
+      const textLastPos = text.length - 1;
+      cm.getDoc().setCursor({
+        line: change.to.line + textLastPos,
+        ch: text[textLastPos].length,
+      });
       break;
     }
 


### PR DESCRIPTION
**What**:
This PR fixes #297 keeping the `Editor` cursor cursor in the right position after paste event.

**Why**:

To fix #297 

**How**:

Calculating the last position based on the text pasted and moving the cursor there.

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests N/A
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
