### PR TITLE
fix: close menu popovers when clicking inside preview pane

### DIFF
--- a/src/components/Preview.js
+++ b/src/components/Preview.js
@@ -34,8 +34,18 @@ function Preview({ markup, variant, forwardedRef, dispatch }) {
 
   const frameRef = useRef();
 
-  const refSetter = useCallback((node) => {
-    frameRef.current = node;
+  useEffect(() => {
+    if (!frameRef.current) {
+      return;
+    }
+
+    frameRef.current.contentWindow.addEventListener('click', () => {
+      const click = new MouseEvent('mousedown', {
+        bubbles: true,
+        cancelable: true,
+      });
+      document.body.dispatchEvent(click);
+    });
   }, []);
 
   const handleLoadIframe = useCallback(() => {
@@ -88,7 +98,7 @@ function Preview({ markup, variant, forwardedRef, dispatch }) {
   return (
     <div className="w-full h-full flex flex-col relative">
       <iframe
-        ref={refSetter}
+        ref={frameRef}
         src="/sandbox.html"
         security="restricted"
         className="flex-auto"


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: https://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

This PR fixes #243 

<!-- Why are these changes necessary? -->

**Why**:

The way the browser work is how it's behaving, but it's a bit annoying to have popovers hanging around when clicking on the preview. Specially because the end user doesn't know that's an iframe.

<!-- How were these changes implemented? -->

**How**:

Attaching a listener to the `iframe` and propagating a `mousedown` on the body of the current window.

![Nov-16-2020 16-42-29](https://user-images.githubusercontent.com/922348/99282328-75345200-282b-11eb-8739-79d8d236650e.gif)


<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests. N/A
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
