### PR TITLE
fix: correct space between tabs

### DIFF
--- a/src/components/Playground.js
+++ b/src/components/Playground.js
@@ -48,7 +48,6 @@ function Playground() {
           </div>
         </div>
 
-        <div className="flex-none h-3" />
         <PlaygroundPanels />
       </div>
     </Layout>

--- a/src/components/PlaygroundPanels.js
+++ b/src/components/PlaygroundPanels.js
@@ -28,19 +28,20 @@ function PlaygroundPanels() {
 
   return (
     <>
-      <div className="px-4 gap-4 flex py-2">
-        {panels.map((panelName) => (
-          <div key={panelName} className="flex items-center">
-            <div className="text-left space-x-2">
+      <div className="px-4 gap-4 flex pt-3 pb-1 h-8">
+        <div className="flex items-center">
+          <div className="text-left space-x-2">
+            {panels.map((panelName) => (
               <TabButton
+                key={panelName}
                 onClick={() => setPanel(panelName)}
                 active={panelName === panel}
               >
                 {panelName}
               </TabButton>
-            </div>
+            ))}
           </div>
-        ))}
+        </div>
       </div>
       <Suspense fallback={null}>
         {panel === panels[0] && (


### PR DESCRIPTION
Before:

![image](https://user-images.githubusercontent.com/1196524/101025368-c5264f00-3575-11eb-93a1-ca5c5b1b6c53.png)


After:

![image](https://user-images.githubusercontent.com/1196524/101025419-d707f200-3575-11eb-8781-f52da3ff274e.png)
