### PR TITLE
fix: restore change detection in query pane

### DIFF
--- a/src/components/Playground.js
+++ b/src/components/Playground.js
@@ -48,7 +48,7 @@ function Playground() {
           </div>
         </div>
 
-        <PlaygroundPanels />
+        <PlaygroundPanels state={state} dispatch={dispatch} />
       </div>
     </Layout>
   );

--- a/src/components/PlaygroundPanels.js
+++ b/src/components/PlaygroundPanels.js
@@ -1,8 +1,5 @@
 import React, { Suspense } from 'react';
 import { useState } from 'react';
-import { useParams } from 'react-router-dom';
-
-import usePlayground from '../hooks/usePlayground';
 
 import Query from './Query';
 import Result from './Result';
@@ -20,9 +17,7 @@ function Paper({ children }) {
   );
 }
 
-function PlaygroundPanels() {
-  const { gistId, gistVersion } = useParams();
-  const [state, dispatch] = usePlayground({ gistId, gistVersion });
+function PlaygroundPanels({ state, dispatch }) {
   const { query, result } = state;
   const [panel, setPanel] = useState(panels[0]);
 


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: https://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

`Playground` now passes `state` and `dispatch` to `PlaygroundPanels` and `PlaygroundPanels` does not call any more `usePlayground` hook to retrieve these two values.

<!-- Why are these changes necessary? -->

**Why**:

This fixes #314 introduced by #296.

<!-- How were these changes implemented? -->

**How**:

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
