### PR TITLE
fix: improve icon button color contrast

### DIFF
--- a/src/components/IconButton.js
+++ b/src/components/IconButton.js
@@ -1,8 +1,8 @@
 import React from 'react';
 
 const variants = {
-  dark: 'text-gray-600 hover:text-gray-400',
-  light: 'text-gray-400 hover:text-gray-600',
+  dark: 'text-gray-500 hover:text-gray-400',
+  light: 'text-gray-500 hover:text-gray-700',
   white: 'text-white hover:text-white',
 };
 

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,3 +1,15 @@
+const { colors } = require('tailwindcss/defaultTheme');
+
 module.exports = {
   purge: false,
+  theme: {
+    extend: {
+      colors: {
+        gray: {
+          ...colors.gray,
+          500: '#728DA7',
+        },
+      },
+    },
+  },
 };


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: https://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

This PR fixes https://github.com/testing-library/testing-playground/issues/343 by improving the color contrast between foreground and background colors used with several interactive UI elements. 

<!-- Why are these changes necessary? -->

**Why**: 

Insufficient color contrast was causing the expand/collapse trigger element difficult to see for non-impaired and impaired users. This is an interactive element and its clickable target is small, so if a user cannot see the `<IconButton>`, they cannot expand/collapse certain elements.

<!-- How were these changes implemented? -->

**How**:

The default color used for `gray-500` was overridden with a darker shade via extending the `tailwind.config.js`. In addition, the `<IconButton>` component was updated to make its `light` and `dark` variants use the new color.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [x] Tests
- [X] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->

Below artifacts show examples of the fix and new contrast ratios ("pass" for graphical objects is the relevant one):

<img width="84" alt="Screen Shot 2022-05-30 at 10 58 12 PM" src="https://user-images.githubusercontent.com/1016306/171084155-042793b3-3d92-485b-964b-1a039f134cb1.png">

<img width="100" alt="Screen Shot 2022-05-30 at 10 58 04 PM" src="https://user-images.githubusercontent.com/1016306/171084202-edfd964e-5c23-46d4-8dc7-bde41a2d71a7.png">

<img width="750" alt="Screen Shot 2022-05-30 at 11 02 04 PM" src="https://user-images.githubusercontent.com/1016306/171084436-490b3447-fecf-4069-aea5-d381fae5d946.png">

<img width="750" alt="Screen Shot 2022-05-30 at 11 00 55 PM" src="https://user-images.githubusercontent.com/1016306/171084464-77d28fd5-92a5-4604-93ed-e89c440f8acc.png">
