### PR TITLE
fix: sandbox not render another queries

### DIFF
--- a/src/sandbox.js
+++ b/src/sandbox.js
@@ -127,9 +127,8 @@ function Sandbox() {
 function checkQuery(queries) {
   const suggestions = Object.values(queries).filter(Boolean);
   const suggestion = Object.values(queries).find(Boolean);
-  let anotherSuggestion;
 
-  anotherSuggestion = suggestions.find(
+  const anotherSuggestion = suggestions.find(
     (query) =>
       query?.queryName && !query.snippet?.startsWith('// sorry, I failed'),
   );

--- a/src/sandbox.js
+++ b/src/sandbox.js
@@ -124,6 +124,19 @@ function Sandbox() {
   );
 }
 
+function checkQuery(queries) {
+  const suggestions = Object.values(queries).filter(Boolean);
+  const suggestion = Object.values(queries).find(Boolean);
+  let anotherSuggestion;
+
+  anotherSuggestion = suggestions.find(
+    (query) =>
+      query?.queryName && !query.snippet?.startsWith('// sorry, I failed'),
+  );
+
+  return anotherSuggestion ? anotherSuggestion : suggestion;
+}
+
 function onSelectNode(node, { origin }) {
   // onSelectNode can be triggered after onMouseLeave has already been called.
   // This makes it impossible to clear hover state. That's why we maintain and
@@ -138,7 +151,8 @@ function onSelectNode(node, { origin }) {
     rootNode: state.rootNode,
   });
 
-  const suggestion = Object.values(queries).find(Boolean);
+  const suggestion = checkQuery(queries);
+
   if (!suggestion) {
     return;
   }


### PR DESCRIPTION
<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:
As mentioned in this [issue](https://github.com/testing-library/testing-playground/issues/338), when we have a list, the tool does not show us other possible query options.

Example:
<img width="686" alt="image" src="https://user-images.githubusercontent.com/106157862/191276446-0ea7d19c-25d1-4e47-83a3-c0f54df3d04f.png">



**Why**:
To improve the developer experience, the following function was added, basically we check if there is any valid query, if there is none, it works with the previous implementation.

```js
function checkQuery(queries) {
  const suggestions = Object.values(queries).filter(Boolean);
  const suggestion = Object.values(queries).find(Boolean);
  
  const anotherSuggestion = suggestions.find(
    (query) =>
      query?.queryName && !query.snippet?.startsWith('// sorry, I failed'),
  );

  return anotherSuggestion ? anotherSuggestion : suggestion;
}
```

Print screen:
<img width="1401" alt="image" src="https://user-images.githubusercontent.com/106157862/191278917-20f93433-e43d-48d0-8320-2dff752429a6.png">

As it maintains the order of the elements, the best query will be used


**How**:
Implementation is complete and tests continue to pass

**Checklist**:

- [x] Tests
- [x] Ready to be merged
