### PR TITLE
Remove broken link to Firefox extension

### DIFF
--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -196,12 +196,6 @@ function Header({
               >
                 Chrome Extension
               </MenuLink>
-              <MenuLink
-                href="https://addons.mozilla.org/en-US/firefox/addon/testing-playground"
-                target="_blank"
-              >
-                Firefox Extension
-              </MenuLink>
 
               <div className="border-b border-gray-200 mx-4 my-2" />
 


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: https://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

Removing the link to the Firefox extension from the page

<!-- Why are these changes necessary? -->

**Why**:

The link is broken and the extension doesn't seem to exist under a new link either as far as I can see from the Firefox extension site and #344.

<!-- How were these changes implemented? -->

**How**:

Removing the link from the top bar

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [x] Tests N/A
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->

Thanks in advance for the help! :)
