### PR TITLE
Add missing embed.js file to built output

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -15,6 +15,7 @@ export default defineConfig(() => {
     r('src', 'index.html'),
     r('src', 'sandbox.html'),
     __DEV__ && r('src', 'embed.html'),
+    r('src', 'embed.js'),
   ].filter(Boolean);
 
   return {


### PR DESCRIPTION
**What**:

`/embed.js` file is missing from the built output.

**Why**:

While the embed.js file is missing it is not possible to load the embed.js file:

```
<script async src="https://testing-playground.com/embed.js"></script>
```

**How**:

Added embed.js to the built output.

**Checklist**:

- [ ] Tests N/A
- [x] Ready to be merged
